### PR TITLE
OPENEUROPA-1792: Translate string 'Resources for partners'.

### DIFF
--- a/config/install/language/bg/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/bg/oe_corporate_blocks.data.footer.yml
@@ -34,7 +34,7 @@ bottom_links:
     label: 'За новото присъствие на Комисията в интернет'
   -
     href: 'http://ec.europa.eu/info/resources-partners_bg'
-    label: 'Resources for partners'
+    label: 'Ресурси за партньори'
   -
     href: 'https://ec.europa.eu/info/language-policy_bg'
     label: 'Езикова политика'

--- a/config/install/language/cs/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/cs/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Jazyková politika'
   -
     href: 'http://ec.europa.eu/info/resources-partners_cs'
-    label: 'Resources for partners'
+    label: 'Zdroje a pokyny pro naše partnery'
   -
     href: 'https://ec.europa.eu/info/cookies_cs'
     label: Cookies

--- a/config/install/language/da/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/da/oe_corporate_blocks.data.footer.yml
@@ -34,7 +34,7 @@ bottom_links:
     label: 'Om Kommissionens nye website'
   -
     href: 'http://ec.europa.eu/info/resources-partners_da'
-    label: 'Resources for partners'
+    label: 'Ressourcer for partnere'
   -
     href: 'https://ec.europa.eu/info/language-policy_da'
     label: Sprogpolitik

--- a/config/install/language/de/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/de/oe_corporate_blocks.data.footer.yml
@@ -34,7 +34,7 @@ bottom_links:
     label: 'Über den neuen Internetauftritt der Kommission'
   -
     href: 'http://ec.europa.eu/info/resources-partners_de'
-    label: 'Resources for partners'
+    label: 'Ressourcen für Partner'
   -
     href: 'https://ec.europa.eu/info/language-policy_de'
     label: Sprachenpolitik

--- a/config/install/language/el/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/el/oe_corporate_blocks.data.footer.yml
@@ -34,7 +34,7 @@ bottom_links:
     label: 'About the Commission''s new web presence'
   -
     href: 'http://ec.europa.eu/info/resources-partners_el'
-    label: 'Resources for partners'
+    label: 'Πόροι για εταίρους'
   -
     href: 'https://ec.europa.eu/info/language-policy_el'
     label: 'Γλωσσική πολιτική'

--- a/config/install/language/es/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/es/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Política lingüística'
   -
     href: 'http://ec.europa.eu/info/resources-partners_es'
-    label: 'Resources for partners'
+    label: 'Recursos disponibles'
   -
     href: 'https://ec.europa.eu/info/cookies_es'
     label: Cookies

--- a/config/install/language/et/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/et/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: EKeelepoliitika
   -
     href: 'http://ec.europa.eu/info/resources-partners_et'
-    label: 'Resources for partners'
+    label: 'Materjalid partneritele'
   -
     href: 'https://ec.europa.eu/info/cookies_et'
     label: Küpsised

--- a/config/install/language/fi/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/fi/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: Kielipolitiikka
   -
     href: 'http://ec.europa.eu/info/resources-partners_fi'
-    label: 'Resources for partners'
+    label: 'Apuvälineitä yhteistyökumppaneille'
   -
     href: 'https://ec.europa.eu/info/cookies_fi'
     label: Evästeet

--- a/config/install/language/fr/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/fr/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Politique linguistique'
   -
     href: 'http://ec.europa.eu/info/resources-partners_fr'
-    label: 'Resources for partners'
+    label: 'Ressources pour les partenaires'
   -
     href: 'https://ec.europa.eu/info/cookies_fr'
     label: Cookies

--- a/config/install/language/ga/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/ga/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Beartas teanga'
   -
     href: 'http://ec.europa.eu/info/resources-partners_ga'
-    label: 'Resources for partners'
+    label: 'Acmhainní le haghaidh comhpháirtithe'
   -
     href: 'https://ec.europa.eu/info/cookies_ga'
     label: Fianáin

--- a/config/install/language/hr/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/hr/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Jezična politika'
   -
     href: 'http://ec.europa.eu/info/resources-partners_hr'
-    label: 'Resources for partners'
+    label: 'Resursi za partnere'
   -
     href: 'https://ec.europa.eu/info/cookies_hr'
     label: Kolačići

--- a/config/install/language/hu/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/hu/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: Nyelvpolitika
   -
     href: 'http://ec.europa.eu/info/resources-partners_hu'
-    label: 'Resources for partners'
+    label: 'Erőforrások, segédeszközök'
   -
     href: 'https://ec.europa.eu/info/cookies_hu'
     label: Cookie-k

--- a/config/install/language/it/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/it/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Politica linguistica'
   -
     href: 'http://ec.europa.eu/info/resources-partners_it'
-    label: 'Resources for partners'
+    label: 'Risorse per i partner'
   -
     href: 'https://ec.europa.eu/info/cookies_it'
     label: Cookies

--- a/config/install/language/lt/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/lt/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Kalbų politika'
   -
     href: 'http://ec.europa.eu/info/resources-partners_lt'
-    label: 'Resources for partners'
+    label: 'Ištekliai partneriams'
   -
     href: 'https://ec.europa.eu/info/cookies_lt'
     label: Slapukai

--- a/config/install/language/lv/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/lv/oe_corporate_blocks.data.footer.yml
@@ -34,7 +34,7 @@ bottom_links:
     label: 'Par Komisijas jauno tīmekļa vietni'
   -
     href: 'http://ec.europa.eu/info/resources-partners_lv'
-    label: 'Resources for partners'
+    label: 'Resursi partneriem'
   -
     href: 'https://ec.europa.eu/info/language-policy_lv'
     label: 'Valodu politika'

--- a/config/install/language/mt/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/mt/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Il-politika tal-lingwi'
   -
     href: 'http://ec.europa.eu/info/resources-partners_mt'
-    label: 'Resources for partners'
+    label: 'Riżorsi għas-sħab'
   -
     href: 'https://ec.europa.eu/info/cookies_mt'
     label: Cookies

--- a/config/install/language/nl/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/nl/oe_corporate_blocks.data.footer.yml
@@ -34,7 +34,7 @@ bottom_links:
     label: 'Over de nieuwe website van de Europese Commissie'
   -
     href: 'http://ec.europa.eu/info/resources-partners_nl'
-    label: 'Resources for partners'
+    label: 'Bronmateriaal voor partners'
   -
     href: 'https://ec.europa.eu/info/language-policy_nl'
     label: Talenbeleid

--- a/config/install/language/pl/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/pl/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Polityka językowa'
   -
     href: 'http://ec.europa.eu/info/resources-partners_pl'
-    label: 'Resources for partners'
+    label: 'Materiały dla partnerów'
   -
     href: 'https://ec.europa.eu/info/cookies_pl'
     label: 'Pliki cookie'

--- a/config/install/language/pt-pt/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/pt-pt/oe_corporate_blocks.data.footer.yml
@@ -40,7 +40,7 @@ bottom_links:
     label: 'Recursos disponíveis'
   -
     href: 'https://ec.europa.eu/info/cookies_pt'
-    label: 'Cookies testemunhos de conexãob'
+    label: 'Cookies'
   -
     href: 'https://ec.europa.eu/info/privacy-policy_pt'
     label: 'Política de privacidade'

--- a/config/install/language/pt-pt/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/pt-pt/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Política em matéria de línguas'
   -
     href: 'http://ec.europa.eu/info/resources-partners_pt'
-    label: 'Resources for partners'
+    label: 'Recursos disponíveis'
   -
     href: 'https://ec.europa.eu/info/cookies_pt'
     label: 'Cookies testemunhos de conexãob'

--- a/config/install/language/ro/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/ro/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Politica lingvistică'
   -
     href: 'http://ec.europa.eu/info/resources-partners_ro'
-    label: 'Resources for partners'
+    label: 'Resurse pentru parteneri'
   -
     href: 'https://ec.europa.eu/info/cookies_ro'
     label: Cookie-urile

--- a/config/install/language/sk/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/sk/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Jazyková politika'
   -
     href: 'http://ec.europa.eu/info/resources-partners_sk'
-    label: 'Resources for partners'
+    label: 'Resurse pentru parteneri'
   -
     href: 'https://ec.europa.eu/info/cookies_sk'
     label: 'Súbory cookie'

--- a/config/install/language/sl/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/sl/oe_corporate_blocks.data.footer.yml
@@ -37,7 +37,7 @@ bottom_links:
     label: 'Jezikovna politika'
   -
     href: 'http://ec.europa.eu/info/resources-partners_sl'
-    label: 'Resources for partners'
+    label: 'Viri za partnerje'
   -
     href: 'https://ec.europa.eu/info/cookies_sl'
     label: Piškotki

--- a/config/install/language/sv/oe_corporate_blocks.data.footer.yml
+++ b/config/install/language/sv/oe_corporate_blocks.data.footer.yml
@@ -34,7 +34,7 @@ bottom_links:
     label: 'Om kommissionens nya webbplats'
   -
     href: 'http://ec.europa.eu/info/resources-partners_sv'
-    label: 'Resources for partners'
+    label: 'Resurser för partner'
   -
     href: 'https://ec.europa.eu/info/language-policy_sv'
     label: Språkpolicy

--- a/tests/features/corporate-blocks.feature
+++ b/tests/features/corporate-blocks.feature
@@ -64,7 +64,7 @@ Feature: Corporate blocks feature
     | Union européenne                                             | https://europa.eu/european-union/index_fr                                   |
     | À propos de la nouvelle présence de la Commission sur le web | https://ec.europa.eu/info/about-commissions-new-web-presence_fr             |
     | Politique linguistique                                       | https://ec.europa.eu/info/language-policy_fr                                |
-    | Resources for partners                                       | http://ec.europa.eu/info/resources-partners_fr                             |
+    | Ressources pour les partenaires                              | http://ec.europa.eu/info/resources-partners_fr                             |
     | Cookies                                                      | https://ec.europa.eu/info/cookies_fr                                        |
     | Protection de la vie privée                                  | https://ec.europa.eu/info/privacy-policy_fr                                 |
     | Avis juridique                                               | https://ec.europa.eu/info/legal-notice_fr                                   |


### PR DESCRIPTION
## OPENEUROPA-1792

### Description

"Resources for partners" has no translation in the system. Translate and update configuration

### Change log

- Added: Translation for "Resources for partners" string
