### PR TITLE
OPENEUROPA-2394: Update footer links for 2.x.

### DIFF
--- a/config/install/oe_corporate_blocks.data.footer.yml
+++ b/config/install/oe_corporate_blocks.data.footer.yml
@@ -1,10 +1,8 @@
 langcode: en
 about_ec_title: European Commission
 about_ec_links:
-  - href: https://ec.europa.eu/commission/index_en
-    label: Commission and its priorities
   - href: https://ec.europa.eu/info/index_en
-    label: Policies, information and services
+    label: European Commission website
 social_media_title: Follow the European Commission
 social_media_links:
   - type: social-network

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Corporate Blocks post updates.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Update corporate footer.
+ */
+function oe_corporate_blocks_post_update_00001(&$sandbox) {
+  $config = \Drupal::configFactory()->getEditable('oe_corporate_blocks.data.footer');
+  $config->set('about_ec_links', [
+    [
+      'href' => 'https://ec.europa.eu/info/index_en',
+      'label' => 'European Commission website',
+    ]
+  ]);
+  $config->save();
+}

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -10,7 +10,7 @@ declare(strict_types = 1);
 /**
  * Update corporate footer.
  */
-function oe_corporate_blocks_post_update_00001(&$sandbox): void {
+function oe_corporate_blocks_post_update_10001(&$sandbox): void {
   $config = \Drupal::configFactory()->getEditable('oe_corporate_blocks.data.footer');
   $config->set('about_ec_links', [
     [
@@ -19,4 +19,23 @@ function oe_corporate_blocks_post_update_00001(&$sandbox): void {
     ],
   ]);
   $config->save();
+  // We have to update configuration also for translated configs manually.
+  $language_manager = \Drupal::languageManager();
+  $default_language = $language_manager->getDefaultLanguage()->getId();
+  foreach ($language_manager->getLanguages() as $language) {
+    if ($default_language === $language->getId()) {
+      continue;
+    }
+    $config_translation = $language_manager->getLanguageConfigOverride($language->getId(), 'oe_corporate_blocks.data.footer');
+    $config_translation->set(
+      'about_ec_links', [
+        [
+          'href' => 'https://ec.europa.eu/info/index_en',
+          'label' => 'European Commission website',
+        ],
+      ]
+    );
+    $config_translation->save();
+  }
+
 }

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -10,13 +10,13 @@ declare(strict_types = 1);
 /**
  * Update corporate footer.
  */
-function oe_corporate_blocks_post_update_00001(&$sandbox) {
+function oe_corporate_blocks_post_update_00001(&$sandbox): void {
   $config = \Drupal::configFactory()->getEditable('oe_corporate_blocks.data.footer');
   $config->set('about_ec_links', [
     [
       'href' => 'https://ec.europa.eu/info/index_en',
       'label' => 'European Commission website',
-    ]
+    ],
   ]);
   $config->save();
 }

--- a/tests/features/corporate-blocks.feature
+++ b/tests/features/corporate-blocks.feature
@@ -8,11 +8,13 @@ Feature: Corporate blocks feature
     When I am on "the <path> page"
 
     Then Links in the "header" region contains the links:
-      | European Commission website | https://ec.europa.eu/info/index_en       |
+      | Commission and its priorities      | https://ec.europa.eu/commission/index_en |
+      | Policies, information and services | https://ec.europa.eu/info/index_en       |
 
     When I click "français" in the "header"
     Then Links in the "header" region contains the links:
-      | Site web de la Commission européenne | https://ec.europa.eu/info/index_fr       |
+      | La Commission et ses priorités       | https://ec.europa.eu/commission/index_fr |
+      | Politiques, informations et services | https://ec.europa.eu/info/index_fr       |
 
     Examples:
       | path  |
@@ -29,40 +31,40 @@ Feature: Corporate blocks feature
     And I should see "Follow the European Commission" in the "footer" region
     And I should see "European Union" in the "footer" region
     And Links in the "footer" region contains the links:
-    | European Commission website             | https://ec.europa.eu/info/index_en                                          |
-    | Facebook                                | https://www.facebook.com/EuropeanCommission                                 |
-    | Twitter                                 | https://twitter.com/EU_commission                                           |
-    | Other social media                      | https://europa.eu/european-union/contact/social-networks_en#n:+i:4+e:1+t:+s |
-    | EU institutions                         | https://europa.eu/european-union/about-eu/institutions-bodies_en            |
-    | European Union                          | https://europa.eu/european-union/index_en                                   |
-    | About the Commission's new web presence | https://ec.europa.eu/info/about-commissions-new-web-presence_en             |
-    | Language policy                         | https://ec.europa.eu/info/language-policy_en                                |
-    | Resources for partners                  | https://ec.europa.eu/info/resources-partners_en                             |
-    | Cookies                                 | https://ec.europa.eu/info/cookies_en                                        |
-    | Privacy policy                          | https://ec.europa.eu/info/privacy-policy_en                                 |
-    | Legal notice                            | https://ec.europa.eu/info/legal-notice_en                                   |
-    | Contact                                 | https://ec.europa.eu/info/contact_en                                        |
+      | European Commission website             | https://ec.europa.eu/info/index_en                                          |
+      | Facebook                                | https://www.facebook.com/EuropeanCommission                                 |
+      | Twitter                                 | https://twitter.com/EU_commission                                           |
+      | Other social media                      | https://europa.eu/european-union/contact/social-networks_en#n:+i:4+e:1+t:+s |
+      | EU institutions                         | https://europa.eu/european-union/about-eu/institutions-bodies_en            |
+      | European Union                          | https://europa.eu/european-union/index_en                                   |
+      | About the Commission's new web presence | https://ec.europa.eu/info/about-commissions-new-web-presence_en             |
+      | Language policy                         | https://ec.europa.eu/info/language-policy_en                                |
+      | Resources for partners                  | https://ec.europa.eu/info/resources-partners_en                             |
+      | Cookies                                 | https://ec.europa.eu/info/cookies_en                                        |
+      | Privacy policy                          | https://ec.europa.eu/info/privacy-policy_en                                 |
+      | Legal notice                            | https://ec.europa.eu/info/legal-notice_en                                   |
+      | Contact                                 | https://ec.europa.eu/info/contact_en                                        |
 
     When I click "français" in the "header"
     Then I should see "Commission européenne" in the "footer" region
     And I should see "Suivre la Commission européenne" in the "footer" region
     And I should see "Union européenne" in the "footer" region
     And Links in the "footer" region contains the links:
-    | Site web de la Commission européenne                         | https://ec.europa.eu/info/index_fr                                          |
-    | Facebook                                                     | https://www.facebook.com/EuropeanCommission                                 |
-    | Twitter                                                      | https://twitter.com/EU_commission                                           |
-    | Autres réseaux sociaux                                       | https://europa.eu/european-union/contact/social-networks_fr#n:+i:4+e:1+t:+s |
-    | Institutions de l’UE                                         | https://europa.eu/european-union/about-eu/institutions-bodies_fr            |
-    | Union européenne                                             | https://europa.eu/european-union/index_fr                                   |
-    | À propos de la nouvelle présence de la Commission sur le web | https://ec.europa.eu/info/about-commissions-new-web-presence_fr             |
-    | Politique linguistique                                       | https://ec.europa.eu/info/language-policy_fr                                |
-    | Ressources pour les partenaires                              | http://ec.europa.eu/info/resources-partners_fr                             |
-    | Cookies                                                      | https://ec.europa.eu/info/cookies_fr                                        |
-    | Protection de la vie privée                                  | https://ec.europa.eu/info/privacy-policy_fr                                 |
-    | Avis juridique                                               | https://ec.europa.eu/info/legal-notice_fr                                   |
-    | Contact                                                      | https://ec.europa.eu/info/contact_fr                                        |
+      | Site web de la Commission européenne                         | https://ec.europa.eu/info/index_fr                                          |
+      | Facebook                                                     | https://www.facebook.com/EuropeanCommission                                 |
+      | Twitter                                                      | https://twitter.com/EU_commission                                           |
+      | Autres réseaux sociaux                                       | https://europa.eu/european-union/contact/social-networks_fr#n:+i:4+e:1+t:+s |
+      | Institutions de l’UE                                         | https://europa.eu/european-union/about-eu/institutions-bodies_fr            |
+      | Union européenne                                             | https://europa.eu/european-union/index_fr                                   |
+      | À propos de la nouvelle présence de la Commission sur le web | https://ec.europa.eu/info/about-commissions-new-web-presence_fr             |
+      | Politique linguistique                                       | https://ec.europa.eu/info/language-policy_fr                                |
+      | Ressources pour les partenaires                              | http://ec.europa.eu/info/resources-partners_fr                              |
+      | Cookies                                                      | https://ec.europa.eu/info/cookies_fr                                        |
+      | Protection de la vie privée                                  | https://ec.europa.eu/info/privacy-policy_fr                                 |
+      | Avis juridique                                               | https://ec.europa.eu/info/legal-notice_fr                                   |
+      | Contact                                                      | https://ec.europa.eu/info/contact_fr                                        |
 
     Examples:
-    | path  |
-    | home  |
-    | login |
+      | path  |
+      | home  |
+      | login |

--- a/tests/features/corporate-blocks.feature
+++ b/tests/features/corporate-blocks.feature
@@ -8,13 +8,11 @@ Feature: Corporate blocks feature
     When I am on "the <path> page"
 
     Then Links in the "header" region contains the links:
-      | Commission and its priorities      | https://ec.europa.eu/commission/index_en |
-      | Policies, information and services | https://ec.europa.eu/info/index_en       |
+      | European Commission website | https://ec.europa.eu/info/index_en       |
 
     When I click "français" in the "header"
     Then Links in the "header" region contains the links:
-      | La Commission et ses priorités       | https://ec.europa.eu/commission/index_fr |
-      | Politiques, informations et services | https://ec.europa.eu/info/index_fr       |
+      | Site web de la Commission européenne | https://ec.europa.eu/info/index_fr       |
 
     Examples:
       | path  |
@@ -31,8 +29,7 @@ Feature: Corporate blocks feature
     And I should see "Follow the European Commission" in the "footer" region
     And I should see "European Union" in the "footer" region
     And Links in the "footer" region contains the links:
-    | Commission and its priorities           | https://ec.europa.eu/commission/index_en                                    |
-    | Policies, information and services      | https://ec.europa.eu/info/index_en                                          |
+    | European Commission website             | https://ec.europa.eu/info/index_en                                          |
     | Facebook                                | https://www.facebook.com/EuropeanCommission                                 |
     | Twitter                                 | https://twitter.com/EU_commission                                           |
     | Other social media                      | https://europa.eu/european-union/contact/social-networks_en#n:+i:4+e:1+t:+s |
@@ -51,8 +48,7 @@ Feature: Corporate blocks feature
     And I should see "Suivre la Commission européenne" in the "footer" region
     And I should see "Union européenne" in the "footer" region
     And Links in the "footer" region contains the links:
-    | La Commission et ses priorités                               | https://ec.europa.eu/commission/index_fr                                    |
-    | Politiques, informations et services                         | https://ec.europa.eu/info/index_fr                                          |
+    | Site web de la Commission européenne                         | https://ec.europa.eu/info/index_fr                                          |
     | Facebook                                                     | https://www.facebook.com/EuropeanCommission                                 |
     | Twitter                                                      | https://twitter.com/EU_commission                                           |
     | Autres réseaux sociaux                                       | https://europa.eu/european-union/contact/social-networks_fr#n:+i:4+e:1+t:+s |

--- a/translations/oe_corporate_blocks-bg.po
+++ b/translations/oe_corporate_blocks-bg.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Европейска комисия"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_bg"
+
+msgid "Commission and its priorities"
+msgstr "Комисията и нейните приоритети"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_bg"
 
 msgid "European Commission website"
 msgstr "Уебсайт на Европейската комисия"
+
+msgid "Policies, information and services"
+msgstr "Политики, информация и услуги"
 
 msgid "Follow the European Commission"
 msgstr "Следвайте Европейската комисия"

--- a/translations/oe_corporate_blocks-bg.po
+++ b/translations/oe_corporate_blocks-bg.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Европейска комисия"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_bg"
-
-msgid "Commission and its priorities"
-msgstr "Комисията и нейните приоритети"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_bg"
 
-msgid "Policies, information and services"
-msgstr "Политики, информация и услуги"
+msgid "European Commission website"
+msgstr "Уебсайт на Европейската комисия"
 
 msgid "Follow the European Commission"
 msgstr "Следвайте Европейската комисия"

--- a/translations/oe_corporate_blocks-cs.po
+++ b/translations/oe_corporate_blocks-cs.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Evropská komise"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_cs"
-
-msgid "Commission and its priorities"
-msgstr "Komise a její priority"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_cs"
 
-msgid "Policies, information and services"
-msgstr "Oblasti politiky, informace a služby"
+msgid "European Commission website"
+msgstr "Internetové stránky Evropské komise"
 
 msgid "Follow the European Commission"
 msgstr "Sledujte Evropskou komisi"

--- a/translations/oe_corporate_blocks-cs.po
+++ b/translations/oe_corporate_blocks-cs.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Evropská komise"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_cs"
+
+msgid "Commission and its priorities"
+msgstr "Komise a její priority"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_cs"
 
 msgid "European Commission website"
 msgstr "Internetové stránky Evropské komise"
+
+msgid "Policies, information and services"
+msgstr "Oblasti politiky, informace a služby"
 
 msgid "Follow the European Commission"
 msgstr "Sledujte Evropskou komisi"

--- a/translations/oe_corporate_blocks-da.po
+++ b/translations/oe_corporate_blocks-da.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Europa-Kommissionen"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_da"
+
+msgid "Commission and its priorities"
+msgstr "Kommissionen og dens prioriteter"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_da"
 
 msgid "European Commission website"
 msgstr "Europa-Kommissionens eget website"
+
+msgid "Policies, information and services"
+msgstr "Politikker, oplysninger og tjenester"
 
 msgid "Follow the European Commission"
 msgstr "Følg Europa-Kommissionen"

--- a/translations/oe_corporate_blocks-da.po
+++ b/translations/oe_corporate_blocks-da.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Europa-Kommissionen"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_da"
-
-msgid "Commission and its priorities"
-msgstr "Kommissionen og dens prioriteter"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_da"
 
-msgid "Policies, information and services"
-msgstr "Politikker, oplysninger og tjenester"
+msgid "European Commission website"
+msgstr "Europa-Kommissionens eget website"
 
 msgid "Follow the European Commission"
 msgstr "Følg Europa-Kommissionen"

--- a/translations/oe_corporate_blocks-de.po
+++ b/translations/oe_corporate_blocks-de.po
@@ -2,12 +2,6 @@
 msgid "European Commission"
 msgstr "Europäische Kommission"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_de"
-
-msgid "Commission and its priorities"
-msgstr "Prioritäten der Kommission"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_de"
 

--- a/translations/oe_corporate_blocks-de.po
+++ b/translations/oe_corporate_blocks-de.po
@@ -2,8 +2,17 @@
 msgid "European Commission"
 msgstr "Europäische Kommission"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_de"
+
+msgid "Commission and its priorities"
+msgstr "Prioritäten der Kommission"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_de"
+
+msgid "European Commission website"
+msgstr "Website der Europäischen Kommission"
 
 msgid "Policies, information and services"
 msgstr "Politikfelder, Informationen und Dienste"

--- a/translations/oe_corporate_blocks-el.po
+++ b/translations/oe_corporate_blocks-el.po
@@ -2,11 +2,22 @@
 msgid "European Commission"
 msgstr "Ευρωπαϊκή Επιτροπή"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_el"
+
+msgid "Commission and its priorities"
+msgstr ""
+"Η Ευρωπαϊκή Επιτροπή και οι "
+"προτεραιότητές της"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_el"
 
 msgid "European Commission website"
 msgstr "Ιστότοπος της Ευρωπαϊκής Επιτροπής"
+
+msgid "Policies, information and services"
+msgstr "Πολιτικές, πληροφορίες και υπηρεσίες"
 
 msgid "Follow the European Commission"
 msgstr "Ακολουθήστε την Ευρωπαϊκή Επιτροπή"

--- a/translations/oe_corporate_blocks-el.po
+++ b/translations/oe_corporate_blocks-el.po
@@ -2,19 +2,11 @@
 msgid "European Commission"
 msgstr "Ευρωπαϊκή Επιτροπή"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_el"
-
-msgid "Commission and its priorities"
-msgstr ""
-"Η Ευρωπαϊκή Επιτροπή και οι "
-"προτεραιότητές της"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_el"
 
-msgid "Policies, information and services"
-msgstr "Πολιτικές, πληροφορίες και υπηρεσίες"
+msgid "European Commission website"
+msgstr "Ιστότοπος της Ευρωπαϊκής Επιτροπής"
 
 msgid "Follow the European Commission"
 msgstr "Ακολουθήστε την Ευρωπαϊκή Επιτροπή"

--- a/translations/oe_corporate_blocks-es.po
+++ b/translations/oe_corporate_blocks-es.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Comisión Europea"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_es"
+
+msgid "Commission and its priorities"
+msgstr "La Comisión y sus prioridades"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_es"
 
 msgid "European Commission website"
 msgstr "Sitio web de la Comisión Europea"
+
+msgid "Policies, information and services"
+msgstr "Políticas, información y servicios"
 
 msgid "Follow the European Commission"
 msgstr "Seguir a la Comisión Europea"

--- a/translations/oe_corporate_blocks-es.po
+++ b/translations/oe_corporate_blocks-es.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Comisión Europea"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_es"
-
-msgid "Commission and its priorities"
-msgstr "La Comisión y sus prioridades"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_es"
 
-msgid "Policies, information and services"
-msgstr "Políticas, información y servicios"
+msgid "European Commission website"
+msgstr "Sitio web de la Comisión Europea"
 
 msgid "Follow the European Commission"
 msgstr "Seguir a la Comisión Europea"

--- a/translations/oe_corporate_blocks-et.po
+++ b/translations/oe_corporate_blocks-et.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Euroopa Komisjon"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_et"
+
+msgid "Commission and its priorities"
+msgstr "Komisjon ja tema prioriteedid"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_et"
 
 msgid "European Commission website"
 msgstr "Euroopa Komisjoni veebisait"
+
+msgid "Policies, information and services"
+msgstr "Poliitikavaldkonnad, teave ja teenused"
 
 msgid "Follow the European Commission"
 msgstr "Jälgige Euroopa Komisjoni"

--- a/translations/oe_corporate_blocks-et.po
+++ b/translations/oe_corporate_blocks-et.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Euroopa Komisjon"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_et"
-
-msgid "Commission and its priorities"
-msgstr "Komisjon ja tema prioriteedid"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_et"
 
-msgid "Policies, information and services"
-msgstr "Poliitikavaldkonnad, teave ja teenused"
+msgid "European Commission website"
+msgstr "Euroopa Komisjoni veebisait"
 
 msgid "Follow the European Commission"
 msgstr "Jälgige Euroopa Komisjoni"

--- a/translations/oe_corporate_blocks-fi.po
+++ b/translations/oe_corporate_blocks-fi.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Euroopan komissio"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_fi"
+
+msgid "Commission and its priorities"
+msgstr "Komissio ja sen toiminnan painopisteet"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_fi"
 
 msgid "European Commission website"
 msgstr "Euroopan komission verkkosivusto"
+
+msgid "Policies, information and services"
+msgstr "Politiikan alat, palvelut, tietolähteet"
 
 msgid "Follow the European Commission"
 msgstr "Seuraa Euroopan komissiota"

--- a/translations/oe_corporate_blocks-fi.po
+++ b/translations/oe_corporate_blocks-fi.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Euroopan komissio"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_fi"
-
-msgid "Commission and its priorities"
-msgstr "Komissio ja sen toiminnan painopisteet"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_fi"
 
-msgid "Policies, information and services"
-msgstr "Politiikan alat, palvelut, tietolähteet"
+msgid "European Commission website"
+msgstr "Euroopan komission verkkosivusto"
 
 msgid "Follow the European Commission"
 msgstr "Seuraa Euroopan komissiota"

--- a/translations/oe_corporate_blocks-fr.po
+++ b/translations/oe_corporate_blocks-fr.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Commission européenne"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_fr"
-
-msgid "Commission and its priorities"
-msgstr "La Commission et ses priorités"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_fr"
 
-msgid "Policies, information and services"
-msgstr "Politiques, informations et services"
+msgid "European Commission website"
+msgstr "Site web de la Commission européenne"
 
 msgid "Follow the European Commission"
 msgstr "Suivre la Commission européenne"

--- a/translations/oe_corporate_blocks-fr.po
+++ b/translations/oe_corporate_blocks-fr.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Commission européenne"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_fr"
+
+msgid "Commission and its priorities"
+msgstr "La Commission et ses priorités"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_fr"
 
 msgid "European Commission website"
 msgstr "Site web de la Commission européenne"
+
+msgid "Policies, information and services"
+msgstr "Politiques, informations et services"
 
 msgid "Follow the European Commission"
 msgstr "Suivre la Commission européenne"

--- a/translations/oe_corporate_blocks-ga.po
+++ b/translations/oe_corporate_blocks-ga.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "An Coimisiún Eorpach"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_ga"
+
+msgid "Commission and its priorities"
+msgstr "An Coimisiún agus a thosaíochtaí"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_ga"
 
 msgid "European Commission website"
 msgstr "Suíomh gréasáin an Choimisiúin Eorpaigh"
+
+msgid "Policies, information and services"
+msgstr "Beartais, eolas agus seirbhísí"
 
 msgid "Follow the European Commission"
 msgstr "An Coimisiún Eorpach a leanúint"

--- a/translations/oe_corporate_blocks-ga.po
+++ b/translations/oe_corporate_blocks-ga.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "An Coimisiún Eorpach"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_ga"
-
-msgid "Commission and its priorities"
-msgstr "An Coimisiún agus a thosaíochtaí"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_ga"
 
-msgid "Policies, information and services"
-msgstr "Beartais, eolas agus seirbhísí"
+msgid "European Commission website"
+msgstr "Suíomh gréasáin an Choimisiúin Eorpaigh"
 
 msgid "Follow the European Commission"
 msgstr "An Coimisiún Eorpach a leanúint"

--- a/translations/oe_corporate_blocks-hr.po
+++ b/translations/oe_corporate_blocks-hr.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Europska komisija"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_hr"
-
-msgid "Commission and its priorities"
-msgstr "Prioriteti Komisije"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_hr"
 
-msgid "Policies, information and services"
-msgstr "Politike, informacije i službe"
+msgid "European Commission website"
+msgstr "Internetske stranice Europske komisije"
 
 msgid "Follow the European Commission"
 msgstr "Pratite Europsku komisiju"

--- a/translations/oe_corporate_blocks-hr.po
+++ b/translations/oe_corporate_blocks-hr.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Europska komisija"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_hr"
+
+msgid "Commission and its priorities"
+msgstr "Prioriteti Komisije"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_hr"
 
 msgid "European Commission website"
 msgstr "Internetske stranice Europske komisije"
+
+msgid "Policies, information and services"
+msgstr "Politike, informacije i službe"
 
 msgid "Follow the European Commission"
 msgstr "Pratite Europsku komisiju"

--- a/translations/oe_corporate_blocks-hu.po
+++ b/translations/oe_corporate_blocks-hu.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Európai Bizottság"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_hu"
+
+msgid "Commission and its priorities"
+msgstr "A Bizottság és prioritásai"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_hu"
 
 msgid "European Commission website"
 msgstr "Az Európai Bizottság honlapja"
+
+msgid "Policies, information and services"
+msgstr "Szakpolitikák, információk és szolgálatok"
 
 msgid "Follow the European Commission"
 msgstr "Kövessen bennünket!"

--- a/translations/oe_corporate_blocks-hu.po
+++ b/translations/oe_corporate_blocks-hu.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Európai Bizottság"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_hu"
-
-msgid "Commission and its priorities"
-msgstr "A Bizottság és prioritásai"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_hu"
 
-msgid "Policies, information and services"
-msgstr "Szakpolitikák, információk és szolgálatok"
+msgid "European Commission website"
+msgstr "Az Európai Bizottság honlapja"
 
 msgid "Follow the European Commission"
 msgstr "Kövessen bennünket!"

--- a/translations/oe_corporate_blocks-it.po
+++ b/translations/oe_corporate_blocks-it.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Commissione europea"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_it"
+
+msgid "Commission and its priorities"
+msgstr "Le priorità della Commissione"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_it"
 
 msgid "European Commission website"
 msgstr "Sito web della Commissione europea"
+
+msgid "Policies, information and services"
+msgstr "Politiche, informazioni e servizi"
 
 msgid "Follow the European Commission"
 msgstr "Segui la Commissione europea"

--- a/translations/oe_corporate_blocks-it.po
+++ b/translations/oe_corporate_blocks-it.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Commissione europea"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_it"
-
-msgid "Commission and its priorities"
-msgstr "Le priorità della Commissione"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_it"
 
-msgid "Policies, information and services"
-msgstr "Politiche, informazioni e servizi"
+msgid "European Commission website"
+msgstr "Sito web della Commissione europea"
 
 msgid "Follow the European Commission"
 msgstr "Segui la Commissione europea"

--- a/translations/oe_corporate_blocks-lt.po
+++ b/translations/oe_corporate_blocks-lt.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Europos Komisija"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_lt"
+
+msgid "Commission and its priorities"
+msgstr "Komisija ir jos prioritetai"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_lt"
 
 msgid "European Commission website"
 msgstr "Europos Komisijos interneto svetainė"
+
+msgid "Policies, information and services"
+msgstr "Politika, informacija ir paslaugos"
 
 msgid "Follow the European Commission"
 msgstr "Sekite Europos Komisijos naujienas"

--- a/translations/oe_corporate_blocks-lt.po
+++ b/translations/oe_corporate_blocks-lt.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Europos Komisija"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_lt"
-
-msgid "Commission and its priorities"
-msgstr "Komisija ir jos prioritetai"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_lt"
 
-msgid "Policies, information and services"
-msgstr "Politika, informacija ir paslaugos"
+msgid "European Commission website"
+msgstr "Europos Komisijos interneto svetainė"
 
 msgid "Follow the European Commission"
 msgstr "Sekite Europos Komisijos naujienas"

--- a/translations/oe_corporate_blocks-lv.po
+++ b/translations/oe_corporate_blocks-lv.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Eiropas Komisija"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_lv"
+
+msgid "Commission and its priorities"
+msgstr "Komisija un tās prioritātes"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_lv"
 
 msgid "European Commission website"
 msgstr "Eiropas Komisijas tīmekļa vietne"
+
+msgid "Policies, information and services"
+msgstr "Politikas jomas, informācija un dienesti"
 
 msgid "Follow the European Commission"
 msgstr "Sekojiet Eiropas Komisijai"

--- a/translations/oe_corporate_blocks-lv.po
+++ b/translations/oe_corporate_blocks-lv.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Eiropas Komisija"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_lv"
-
-msgid "Commission and its priorities"
-msgstr "Komisija un tās prioritātes"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_lv"
 
-msgid "Policies, information and services"
-msgstr "Politikas jomas, informācija un dienesti"
+msgid "European Commission website"
+msgstr "Eiropas Komisijas tīmekļa vietne"
 
 msgid "Follow the European Commission"
 msgstr "Sekojiet Eiropas Komisijai"

--- a/translations/oe_corporate_blocks-mt.po
+++ b/translations/oe_corporate_blocks-mt.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Il-Kummissjoni Ewropea"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_mt"
-
-msgid "Commission and its priorities"
-msgstr "Il-Kummissjoni u l-prijoritajiet tagħha"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_mt"
 
-msgid "Policies, information and services"
-msgstr "Politiki, informazzjoni u servizzi"
+msgid "European Commission website"
+msgstr "Is-sit web tal-Kummissjoni Ewropea"
 
 msgid "Follow the European Commission"
 msgstr "Segwi l-Kummissjoni Ewropea"

--- a/translations/oe_corporate_blocks-mt.po
+++ b/translations/oe_corporate_blocks-mt.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Il-Kummissjoni Ewropea"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_mt"
+
+msgid "Commission and its priorities"
+msgstr "Il-Kummissjoni u l-prijoritajiet tagħha"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_mt"
 
 msgid "European Commission website"
 msgstr "Is-sit web tal-Kummissjoni Ewropea"
+
+msgid "Policies, information and services"
+msgstr "Politiki, informazzjoni u servizzi"
 
 msgid "Follow the European Commission"
 msgstr "Segwi l-Kummissjoni Ewropea"

--- a/translations/oe_corporate_blocks-nl.po
+++ b/translations/oe_corporate_blocks-nl.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Europese Commissie"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_nl"
+
+msgid "Commission and its priorities"
+msgstr "Commissarissen en prioriteiten"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_nl"
 
 msgid "European Commission website"
 msgstr "Website van de Europese Commissie"
+
+msgid "Policies, information and services"
+msgstr "Beleid, informatie en diensten"
 
 msgid "Follow the European Commission"
 msgstr "Volg de Europese Commissie"

--- a/translations/oe_corporate_blocks-nl.po
+++ b/translations/oe_corporate_blocks-nl.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Europese Commissie"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_nl"
-
-msgid "Commission and its priorities"
-msgstr "Commissarissen en prioriteiten"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_nl"
 
-msgid "Policies, information and services"
-msgstr "Beleid, informatie en diensten"
+msgid "European Commission website"
+msgstr "Website van de Europese Commissie"
 
 msgid "Follow the European Commission"
 msgstr "Volg de Europese Commissie"

--- a/translations/oe_corporate_blocks-pl.po
+++ b/translations/oe_corporate_blocks-pl.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Komisja Europejska"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_pl"
+
+msgid "Commission and its priorities"
+msgstr "Komisja i jej priorytety"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_pl"
 
 msgid "European Commission website"
 msgstr "Strona internetowa Komisji Europejskiej"
+
+msgid "Policies, information and services"
+msgstr "Obszary polityki, informacje i usługi"
 
 msgid "Follow the European Commission"
 msgstr "Komisja Europejska w mediach społecznościowych"

--- a/translations/oe_corporate_blocks-pl.po
+++ b/translations/oe_corporate_blocks-pl.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Komisja Europejska"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_pl"
-
-msgid "Commission and its priorities"
-msgstr "Komisja i jej priorytety"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_pl"
 
-msgid "Policies, information and services"
-msgstr "Obszary polityki, informacje i usługi"
+msgid "European Commission website"
+msgstr "Strona internetowa Komisji Europejskiej"
 
 msgid "Follow the European Commission"
 msgstr "Komisja Europejska w mediach społecznościowych"

--- a/translations/oe_corporate_blocks-pt-pt.po
+++ b/translations/oe_corporate_blocks-pt-pt.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Comissão Europeia"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_pt"
+
+msgid "Commission and its priorities"
+msgstr "As prioridades da Comissão"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_pt"
 
 msgid "European Commission website"
 msgstr "Sítio Web institucional da Comissão Europeia"
+
+msgid "Policies, information and services"
+msgstr "Políticas, informações e serviços"
 
 msgid "Follow the European Commission"
 msgstr "Siga a Comissão Europeia"

--- a/translations/oe_corporate_blocks-pt-pt.po
+++ b/translations/oe_corporate_blocks-pt-pt.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Comissão Europeia"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_pt"
-
-msgid "Commission and its priorities"
-msgstr "As prioridades da Comissão"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_pt"
 
-msgid "Policies, information and services"
-msgstr "Políticas, informações e serviços"
+msgid "European Commission website"
+msgstr "Sítio Web institucional da Comissão Europeia"
 
 msgid "Follow the European Commission"
 msgstr "Siga a Comissão Europeia"

--- a/translations/oe_corporate_blocks-ro.po
+++ b/translations/oe_corporate_blocks-ro.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Comisia Europeană"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_ro"
+
+msgid "Commission and its priorities"
+msgstr "Comisia și prioritățile sale"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_ro"
 
 msgid "European Commission website"
 msgstr "Site-ul Comisiei Europene"
+
+msgid "Policies, information and services"
+msgstr "Informații și domenii de interes"
 
 msgid "Follow the European Commission"
 msgstr "Urmăriți Comisia Europeană"

--- a/translations/oe_corporate_blocks-ro.po
+++ b/translations/oe_corporate_blocks-ro.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Comisia Europeană"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_ro"
-
-msgid "Commission and its priorities"
-msgstr "Comisia și prioritățile sale"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_ro"
 
-msgid "Policies, information and services"
-msgstr "Informații și domenii de interes"
+msgid "European Commission website"
+msgstr "Site-ul Comisiei Europene"
 
 msgid "Follow the European Commission"
 msgstr "Urmăriți Comisia Europeană"

--- a/translations/oe_corporate_blocks-sk.po
+++ b/translations/oe_corporate_blocks-sk.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Európska komisia"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_sk"
+
+msgid "Commission and its priorities"
+msgstr "Komisia a jej priority"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_sk"
 
 msgid "European Commission website"
 msgstr "Internetové stránky Európskej komisie"
+
+msgid "Policies, information and services"
+msgstr "Politiky, informácie a služby"
 
 msgid "Follow the European Commission"
 msgstr "Sledujte Európsku komisiu"

--- a/translations/oe_corporate_blocks-sk.po
+++ b/translations/oe_corporate_blocks-sk.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Európska komisia"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_sk"
-
-msgid "Commission and its priorities"
-msgstr "Komisia a jej priority"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_sk"
 
-msgid "Policies, information and services"
-msgstr "Politiky, informácie a služby"
+msgid "European Commission website"
+msgstr "Internetové stránky Európskej komisie"
 
 msgid "Follow the European Commission"
 msgstr "Sledujte Európsku komisiu"

--- a/translations/oe_corporate_blocks-sl.po
+++ b/translations/oe_corporate_blocks-sl.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Evropska komisija"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_sl"
+
+msgid "Commission and its priorities"
+msgstr "Komisija in njene prednostne naloge"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_sl"
 
 msgid "European Commission website"
 msgstr "Spletišče Evropske komisije"
+
+msgid "Policies, information and services"
+msgstr "Politike, informacije in službe"
 
 msgid "Follow the European Commission"
 msgstr "Spremljajte Evropsko komisijo"

--- a/translations/oe_corporate_blocks-sl.po
+++ b/translations/oe_corporate_blocks-sl.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Evropska komisija"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_sl"
-
-msgid "Commission and its priorities"
-msgstr "Komisija in njene prednostne naloge"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_sl"
 
-msgid "Policies, information and services"
-msgstr "Politike, informacije in službe"
+msgid "European Commission website"
+msgstr "Spletišče Evropske komisije"
 
 msgid "Follow the European Commission"
 msgstr "Spremljajte Evropsko komisijo"

--- a/translations/oe_corporate_blocks-sv.po
+++ b/translations/oe_corporate_blocks-sv.po
@@ -2,17 +2,11 @@
 msgid "European Commission"
 msgstr "Europeiska kommissionen"
 
-msgid "https://ec.europa.eu/commission/index_en"
-msgstr "https://ec.europa.eu/commission/index_sv"
-
-msgid "Commission and its priorities"
-msgstr "Kommissionen och dess prioriteringar"
-
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_sv"
 
-msgid "Policies, information and services"
-msgstr "Politikområden, information och tjänster"
+msgid "European Commission website"
+msgstr "Europeiska kommissionens webbplats"
 
 msgid "Follow the European Commission"
 msgstr "Följ kommissionen"

--- a/translations/oe_corporate_blocks-sv.po
+++ b/translations/oe_corporate_blocks-sv.po
@@ -2,11 +2,20 @@
 msgid "European Commission"
 msgstr "Europeiska kommissionen"
 
+msgid "https://ec.europa.eu/commission/index_en"
+msgstr "https://ec.europa.eu/commission/index_sv"
+
+msgid "Commission and its priorities"
+msgstr "Kommissionen och dess prioriteringar"
+
 msgid "https://ec.europa.eu/info/index_en"
 msgstr "https://ec.europa.eu/info/index_sv"
 
 msgid "European Commission website"
 msgstr "Europeiska kommissionens webbplats"
+
+msgid "Policies, information and services"
+msgstr "Politikområden, information och tjänster"
 
 msgid "Follow the European Commission"
 msgstr "Följ kommissionen"


### PR DESCRIPTION
## OPENEUROPA-2394

### Description

Please adapt the EC footer to reflect the home page merge by adapting the links in the "European Commission" column following the example provided in ECL playground.

[https://ec.europa.eu/component-library/playground/ec/?path=/story/page-structure-footer--corporate]

Target of the new link should be inherited from the current "Policies, information and services" so it should link to "https://ec.europa.eu/info/index_[language]" (token is just an example - use correct one)

Translations of the text can be found here:
```
 'en' => 'European Commission website',
 'bg' => 'Уебсайт на Европейската комисия',
 'es' => 'Sitio web de la Comisión Europea',
 'cs' => 'Internetové stránky Evropské komise',
 'da' => 'Europa-Kommissionens eget website',
 'de' => 'Website der Europäischen Kommission',
 'et' => 'Euroopa Komisjoni veebisait',
 'el' => 'Ιστότοπος της Ευρωπαϊκής Επιτροπής',
 'fr' => 'Site web de la Commission européenne',
 'ga' => 'Suíomh gréasáin an Choimisiúin Eorpaigh',
 'hr' => 'Internetske stranice Europske komisije',
 'it' => 'Sito web della Commissione europea',
 'lv' => 'Eiropas Komisijas tīmekļa vietne',
 'lt' => 'Europos Komisijos interneto svetainė',
 'hu' => 'Az Európai Bizottság honlapja',
 'mt' => 'Is-sit web tal-Kummissjoni Ewropea',
 'nl' => 'Website van de Europese Commissie',
 'pl' => 'Strona internetowa Komisji Europejskiej',
 'pt-pt' => 'Sítio Web institucional da Comissão Europeia',
 'ro' => 'Site-ul Comisiei Europene',
 'sk' => 'Internetové stránky Európskej komisie',
 'sl' => 'Spletišče Evropske komisije',
 'fi' => 'Euroopan komission verkkosivusto',
 'sv' => 'Europeiska kommissionens webbplats',
```
 
### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

