### PR TITLE
OPENEUROPA-2630: Remove item from EU corporate footer.

### DIFF
--- a/config/install/oe_corporate_blocks.eu_data.footer.yml
+++ b/config/install/oe_corporate_blocks.eu_data.footer.yml
@@ -22,9 +22,6 @@ institution_links:
     label: 'Council of the European Union'
     href: 'http://www.consilium.europa.eu/en/home/'
   -
-    label: 'Presidency of the Council of the EU'
-    href: 'https://www.romania2019.eu/home/'
-  -
     label: 'European Commission'
     href: 'https://ec.europa.eu/commission/index_en'
   -

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -83,3 +83,19 @@ function oe_corporate_blocks_post_update_20003(&$sandbox): void {
   $langcodes = array_keys(\Drupal::languageManager()->getLanguages());
   Locale::config()->updateConfigTranslations(['oe_corporate_blocks'], $langcodes);
 }
+
+/**
+ * Remove 'Presidency of the Council of the EU' inside UE footer.
+ */
+function oe_corporate_blocks_post_update_20004(&$sandbox): void {
+  $config = \Drupal::configFactory()->getEditable('oe_corporate_blocks.eu_data.footer');
+  $institution_links = $config->get('institution_links');
+  foreach ($institution_links as $key => $link) {
+    if ($link['label'] === 'Presidency of the Council of the EU' &&
+      $link['href'] === 'https://www.romania2019.eu/home/') {
+      unset($institution_links[$key]);
+    }
+  }
+  $config->set('institution_links', $institution_links);
+  $config->save();
+}

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -85,14 +85,16 @@ function oe_corporate_blocks_post_update_20003(&$sandbox): void {
 }
 
 /**
- * Remove 'Presidency of the Council of the EU' inside UE footer.
+ * Remove 'Presidency of the Council of the EU' from EU footer.
  */
 function oe_corporate_blocks_post_update_20004(&$sandbox): void {
   $config = \Drupal::configFactory()->getEditable('oe_corporate_blocks.eu_data.footer');
   $institution_links = $config->get('institution_links');
   foreach ($institution_links as $key => $link) {
-    if ($link['label'] === 'Presidency of the Council of the EU' &&
-      $link['href'] === 'https://www.romania2019.eu/home/') {
+    if (
+      $link['label'] === 'Presidency of the Council of the EU' &&
+      $link['href'] === 'https://www.romania2019.eu/home/'
+    ) {
       unset($institution_links[$key]);
     }
   }

--- a/tests/features/corporate-blocks.feature
+++ b/tests/features/corporate-blocks.feature
@@ -1,4 +1,4 @@
-@api @footer
+@api
 Feature: Corporate blocks feature
   In order to be able to showcase Corporate blocks
   As an anonymous user

--- a/tests/features/corporate-blocks.feature
+++ b/tests/features/corporate-blocks.feature
@@ -1,4 +1,4 @@
-@api
+@api @footer
 Feature: Corporate blocks feature
   In order to be able to showcase Corporate blocks
   As an anonymous user
@@ -69,7 +69,6 @@ Feature: Corporate blocks feature
       | European Parliament                           | http://www.europarl.europa.eu/portal/                        |
       | European Council                              | http://www.consilium.europa.eu/en/european-council/          |
       | Council of the European Union                 | http://www.consilium.europa.eu/en/home/                      |
-      | Presidency of the Council of the EU           | https://www.romania2019.eu/home/                             |
       | European Commission                           | https://ec.europa.eu/commission/index_en                     |
       | Court of Justice of the European Union (CJEU) | http://curia.europa.eu/jcms/jcms/j_6/en/                     |
       | European Central Bank (ECB)                   | https://www.ecb.europa.eu/home/html/index.en.html            |
@@ -86,6 +85,8 @@ Feature: Corporate blocks feature
       | Privacy policy                                | /european-union/abouteuropa/privacy-policy_en                |
       | Legal notice                                  | /european-union/abouteuropa/legal_notices_en                 |
       | Cookies                                       | /european-union/abouteuropa/cookies_en                       |
+    And the region "eu_footer" does not contain the links:
+      | Presidency of the Council of the EU           | https://www.romania2019.eu/home/                             |
 
     When I click "français" in the "header"
     And the region "eu_footer" contains the links:
@@ -99,7 +100,6 @@ Feature: Corporate blocks feature
       | European Parliament                                    | http://www.europarl.europa.eu/portal/fr                          |
       | Conseil européen                                       | http://www.consilium.europa.eu/fr/european-council/              |
       | Conseil de l'Union européenne                          | http://www.consilium.europa.eu/fr/home/                          |
-      | Présidence du Conseil de l'UE                          | https://www.romania2019.eu/page-daccueil/                        |
       | Commission européenne                                  | https://ec.europa.eu/commission/index_fr                         |
       | Cour de justice de l'Union européenne (CJUE)           | http://curia.europa.eu/jcms/jcms/j_6/fr/                         |
       | Banque centrale européenne (BCE)                       | https://www.ecb.europa.eu/home/languagepolicy/html/index.fr.html |
@@ -116,6 +116,8 @@ Feature: Corporate blocks feature
       | Protection de la vie privée                            | /european-union/abouteuropa/privacy-policy_fr                    |
       | Avis juridique                                         | /european-union/abouteuropa/legal_notices_fr                     |
       | Cookies                                                | /european-union/abouteuropa/cookies_fr                           |
+    And the region "eu_footer" does not contain the links:
+      | Présidence du Conseil de l'UE                          | https://www.romania2019.eu/page-daccueil/                        |
 
     Examples:
       | path  |

--- a/translations/oe_corporate_blocks-bg.po
+++ b/translations/oe_corporate_blocks-bg.po
@@ -46,12 +46,6 @@ msgstr "Съвет на Европейския съюз"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/bg/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Председателство на Съвета на ЕС"
-
-msgid "https://www.romania2019.eu/home/"
-msgstr ""
-
 msgid "European Commission"
 msgstr "Европейска комисия"
 

--- a/translations/oe_corporate_blocks-cs.po
+++ b/translations/oe_corporate_blocks-cs.po
@@ -46,9 +46,6 @@ msgstr "Rada Evropské unie"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/cs/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Předsednictví Rady EU"
-
 msgid "European Commission"
 msgstr "Evropská komise"
 

--- a/translations/oe_corporate_blocks-da.po
+++ b/translations/oe_corporate_blocks-da.po
@@ -46,9 +46,6 @@ msgstr "Rådet for Den Europæiske Union"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/da/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Formandskabet for EU-Rådet"
-
 msgid "European Commission"
 msgstr "Europa-Kommissionen"
 

--- a/translations/oe_corporate_blocks-de.po
+++ b/translations/oe_corporate_blocks-de.po
@@ -46,9 +46,6 @@ msgstr "Rat der Europäischen Union"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/de/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "EU- Ratspräsidentschaft"
-
 msgid "European Commission"
 msgstr "Europäische Kommission"
 

--- a/translations/oe_corporate_blocks-el.po
+++ b/translations/oe_corporate_blocks-el.po
@@ -46,9 +46,6 @@ msgstr "Συμβούλιο της Ευρωπαϊκής Ένωσης"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/el/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Προεδρία του Συμβουλίου της ΕΕ"
-
 msgid "European Commission"
 msgstr "Ευρωπαϊκή Επιτροπή"
 

--- a/translations/oe_corporate_blocks-es.po
+++ b/translations/oe_corporate_blocks-es.po
@@ -46,9 +46,6 @@ msgstr "Consejo de la Unión Europea"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/es/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Presidencia del Consejo de la UE"
-
 msgid "European Commission"
 msgstr "Comisión Europea"
 

--- a/translations/oe_corporate_blocks-et.po
+++ b/translations/oe_corporate_blocks-et.po
@@ -46,9 +46,6 @@ msgstr "Euroopa Liidu Nõukogu"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/et/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Euroopa Liidu Nõukogu eesistujariik"
-
 msgid "https://ec.europa.eu/commission/index_en"
 msgstr "https://ec.europa.eu/commission/index_et"
 

--- a/translations/oe_corporate_blocks-fi.po
+++ b/translations/oe_corporate_blocks-fi.po
@@ -46,9 +46,6 @@ msgstr "Euroopan unionin neuvosto"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/fi/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Euroopan unionin neuvoston puheenjohtajamaa"
-
 msgid "European Commission"
 msgstr "Euroopan komissio"
 

--- a/translations/oe_corporate_blocks-fr.po
+++ b/translations/oe_corporate_blocks-fr.po
@@ -43,12 +43,6 @@ msgstr "Conseil de l'Union européenne"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/fr/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Présidence du Conseil de l'UE"
-
-msgid "https://www.romania2019.eu/home/"
-msgstr "https://www.romania2019.eu/page-daccueil/"
-
 msgid "European Commission"
 msgstr "Commission européenne"
 

--- a/translations/oe_corporate_blocks-ga.po
+++ b/translations/oe_corporate_blocks-ga.po
@@ -46,9 +46,6 @@ msgstr "Comhairle an Aontais Eorpaigh"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/ga/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Uachtaránacht Chomhairle an AE"
-
 msgid "European Commission"
 msgstr "An Coimisiún Eorpach"
 

--- a/translations/oe_corporate_blocks-hr.po
+++ b/translations/oe_corporate_blocks-hr.po
@@ -46,9 +46,6 @@ msgstr "Vijeće Europske unije"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/hr/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Predsjedništvo Vijeća EU-a"
-
 msgid "European Commission"
 msgstr "Europska komisija"
 

--- a/translations/oe_corporate_blocks-hu.po
+++ b/translations/oe_corporate_blocks-hu.po
@@ -43,9 +43,6 @@ msgstr "Az Európai Unió Tanácsa"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/hu/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Az EU Tanácsának elnöksége"
-
 msgid "European Commission"
 msgstr "Európai Bizottság"
 

--- a/translations/oe_corporate_blocks-it.po
+++ b/translations/oe_corporate_blocks-it.po
@@ -43,9 +43,6 @@ msgstr "http://www.consilium.europa.eu/it/european-council/"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/it/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Presidenza del Consiglio dell'UE"
-
 msgid "European Commission"
 msgstr "Commissione europea"
 

--- a/translations/oe_corporate_blocks-lt.po
+++ b/translations/oe_corporate_blocks-lt.po
@@ -46,9 +46,6 @@ msgstr "Europos Sąjungos Taryba"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/lt/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Pirmininkavimas ES"
-
 msgid "European Commission"
 msgstr "Europos Komisija"
 

--- a/translations/oe_corporate_blocks-lv.po
+++ b/translations/oe_corporate_blocks-lv.po
@@ -46,9 +46,6 @@ msgstr "Eiropas Savienības Padome"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/lv/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "ES Padomes prezidentūra"
-
 msgid "European Commission"
 msgstr "Eiropas Komisija"
 

--- a/translations/oe_corporate_blocks-mt.po
+++ b/translations/oe_corporate_blocks-mt.po
@@ -46,9 +46,6 @@ msgstr "Il-Kunsill tal-Unjoni Ewropea"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/mt/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Presidenza tal-Kunsill tal-UE"
-
 msgid "European Commission"
 msgstr "Il-Kummissjoni Ewropea"
 

--- a/translations/oe_corporate_blocks-nl.po
+++ b/translations/oe_corporate_blocks-nl.po
@@ -46,9 +46,6 @@ msgstr "Raad van de Europese Unie"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/nl/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Voorzitterschap van de Raad van de EU"
-
 msgid "European Commission"
 msgstr "Europese Commissie"
 

--- a/translations/oe_corporate_blocks-pl.po
+++ b/translations/oe_corporate_blocks-pl.po
@@ -46,9 +46,6 @@ msgstr "Rada Unii Europejskiej"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/pl/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Przewodnictwo w Radzie UE"
-
 msgid "European Commission"
 msgstr "Komisja Europejska"
 

--- a/translations/oe_corporate_blocks-pt-pt.po
+++ b/translations/oe_corporate_blocks-pt-pt.po
@@ -43,9 +43,6 @@ msgstr "http://www.consilium.europa.eu/pt/european-council/"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/pt/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Presidência do Conselho da UE"
-
 msgid "European Commission"
 msgstr "Comissão Europeia"
 

--- a/translations/oe_corporate_blocks-ro.po
+++ b/translations/oe_corporate_blocks-ro.po
@@ -46,9 +46,6 @@ msgstr "Consiliul Uniunii Europene"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/ro/home/"
 
-msgid "https://www.romania2019.eu/home/"
-msgstr "https://www.romania2019.eu/"
-
 msgid "European Commission"
 msgstr "Comisia Europeană"
 

--- a/translations/oe_corporate_blocks-sk.po
+++ b/translations/oe_corporate_blocks-sk.po
@@ -46,9 +46,6 @@ msgstr "Rada Európskej únie"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/sk/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Predsedníctvo Rady EÚ"
-
 msgid "European Commission"
 msgstr "Európska komisia"
 

--- a/translations/oe_corporate_blocks-sl.po
+++ b/translations/oe_corporate_blocks-sl.po
@@ -46,9 +46,6 @@ msgstr "Svet Evropske unije"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/sl/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "Predsedovanje Svetu EU"
-
 msgid "https://ec.europa.eu/commission/index_en"
 msgstr "http://ec.europa.eu/index_sl.htm"
 

--- a/translations/oe_corporate_blocks-sv.po
+++ b/translations/oe_corporate_blocks-sv.po
@@ -46,9 +46,6 @@ msgstr "Europeiska unionens råd"
 msgid "http://www.consilium.europa.eu/en/home/"
 msgstr "http://www.consilium.europa.eu/sv/home/"
 
-msgid "Presidency of the Council of the EU"
-msgstr "EU:s ordförandeskap"
-
 msgid "European Commission"
 msgstr "Europeiska kommissionen"
 


### PR DESCRIPTION
## OPENEUROPA-2630

### Description

Please remove the "Presidency of the Council of the EU" link from EU version of the corporate footer.


### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

