### PR TITLE
OPENEUROPA-2800: Fixing footer link URL validation.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -7,6 +7,7 @@ default:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\ConfigContext
+        - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\Tests\oe_corporate_blocks\Behat\CorporateBlocksContext
         - Drupal\Tests\oe_corporate_blocks\Behat\FeatureContext
         - OpenEuropa\Behat\TransformationContext:
@@ -29,5 +30,9 @@ default:
         ec_footer: "div.block-oe-corporate-blocks-ec-footer"
         eu_footer: "div.block-oe-corporate-blocks-eu-footer"
         header: "div.region-header"
+      selectors:
+        message_selector: ".messages"
+        error_message_selector: ".messages.messages--error"
+        success_message_selector: ".messages.messages--status"
   formatters:
     progress: ~

--- a/src/Entity/FooterLinkGeneral.php
+++ b/src/Entity/FooterLinkGeneral.php
@@ -66,6 +66,9 @@ class FooterLinkGeneral extends ConfigEntityBase implements FooterLinkInterface 
    */
   public function getUrl(): Url {
     $input = trim($this->get('url'));
+    if ($input === '<front>') {
+      $input = 'internal:/';
+    }
     if (parse_url($input, PHP_URL_SCHEME) === NULL) {
       $input = 'internal:' . $input;
     }

--- a/src/Form/FooterLinkGeneralForm.php
+++ b/src/Form/FooterLinkGeneralForm.php
@@ -84,9 +84,11 @@ class FooterLinkGeneralForm extends EntityForm {
 
     try {
       $url = Url::fromUri($uri);
+      $url->toString(TRUE);
     }
-    catch (\InvalidArgumentException $exception) {
-      // Mark the url as invalid.
+    catch (\Exception $exception) {
+      // Mark the url as invalid if any kind of exception is being thrown by
+      // the Url class.
       $url = FALSE;
     }
     if ($url === FALSE || ($url->isExternal() && !in_array(parse_url($url->getUri(), PHP_URL_SCHEME), UrlHelper::getAllowedProtocols()))) {

--- a/src/Form/FooterLinkGeneralForm.php
+++ b/src/Form/FooterLinkGeneralForm.php
@@ -56,11 +56,18 @@ class FooterLinkGeneralForm extends EntityForm {
    * {@inheritdoc}
    *
    * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+   * @SuppressWarnings(PHPMD.NPathComplexity)
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
     $uri = trim($form['url']['#value']);
 
     if (parse_url($uri, PHP_URL_SCHEME) === NULL) {
+      if (strpos($uri, '<front>') !== FALSE && $uri !== '<front>') {
+        // Only support the <front> token if it's on its own.
+        $form_state->setError($form['url'], t('The path %uri is invalid.', ['%uri' => $uri]));
+        return;
+      }
+
       if (strpos($uri, '<front>') === 0) {
         $uri = '/' . substr($uri, strlen('<front>'));
       }

--- a/src/Plugin/Block/FooterBlockBase.php
+++ b/src/Plugin/Block/FooterBlockBase.php
@@ -110,7 +110,7 @@ abstract class FooterBlockBase extends BlockBase implements ContainerFactoryPlug
         $cache->addCacheableDependency($link_entity);
 
         $link = [
-          'href' => $link_entity->getUrl()->toString(),
+          'href' => $link_entity->getUrl(),
           'label' => $link_entity->label(),
         ];
 

--- a/tests/features/custom-footer-settings.feature
+++ b/tests/features/custom-footer-settings.feature
@@ -183,3 +183,22 @@ Feature: Site specific footer links management.
       | region    |
       | ec_footer |
       | eu_footer |
+
+  Scenario Outline: Invalid URLs should not be saved in the footer.
+    Given I am logged in as a user with the "access administration pages, administer site specific footer links" permissions
+    When I am on "the footer links manager page"
+    And I click "Add footer link"
+    And I fill in "Label" with "Test"
+    And I fill in "Machine-readable name" with "test"
+    And I fill in "URL" with "<url>"
+    And I press "Save"
+    Then I should see the following error messages:
+      | error messages |
+      | <message>      |
+
+    Examples:
+      | url                | message                                                                                                          |
+      | http://example:com | The path http://example:com is invalid.                                                                          |
+      | htp://example.com  | The path htp://example.com is invalid.                                                                           |
+      | node/1             | The specified target is invalid. Manually entered paths should start with one of the following characters: / ? # |
+      | //                 | The path // is invalid.                                                                                          |

--- a/tests/features/custom-footer-settings.feature
+++ b/tests/features/custom-footer-settings.feature
@@ -202,3 +202,6 @@ Feature: Site specific footer links management.
       | htp://example.com  | The path htp://example.com is invalid.                                                                           |
       | node/1             | The specified target is invalid. Manually entered paths should start with one of the following characters: / ? # |
       | //                 | The path // is invalid.                                                                                          |
+      | /<front>/node/1    | The path /<front>/node/1 is invalid.                                                                             |
+      | <front>/node/1     | The path <front>/node/1 is invalid.                                                                              |
+      | /<front>           | The path /<front> is invalid.                                                                                    |


### PR DESCRIPTION
* Fixing validation of footer links
* Passing directly the Url object to twig to prevent a re-instantiation of the object that can break as well.