### PR TITLE
EWPP-131: Always set site_identity and invalidate container after enabling oe_corporate_site_info.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.2",
         "drupal/core": "^8.7",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/oe_corporate_site_info": "dev-EWPP-131"
+        "openeuropa/oe_corporate_site_info": "dev-master"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.2",
         "drupal/core": "^8.7",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/oe_corporate_site_info": "dev-master"
+        "openeuropa/oe_corporate_site_info": "dev-EWPP-131"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -175,3 +175,10 @@ function oe_corporate_blocks_post_update_30004(): void {
     $general_link->save();
   }
 }
+
+/**
+ * Invalidate kernel container to make site info service available.
+ */
+function oe_corporate_blocks_post_update_30005(): void {
+  \Drupal::service('kernel')->invalidateContainer();
+}

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -122,6 +122,8 @@ function oe_corporate_blocks_post_update_20004(&$sandbox): void {
  */
 function oe_corporate_blocks_post_update_30001(): void {
   \Drupal::service('module_installer')->install(['oe_corporate_site_info']);
+  // Invalidate kernel container to make site info service available.
+  \Drupal::service('kernel')->invalidateContainer();
 }
 
 /**
@@ -174,11 +176,4 @@ function oe_corporate_blocks_post_update_30004(): void {
     $general_link->setSection('related_sites');
     $general_link->save();
   }
-}
-
-/**
- * Invalidate kernel container to make site info service available.
- */
-function oe_corporate_blocks_post_update_30005(): void {
-  \Drupal::service('kernel')->invalidateContainer();
 }

--- a/src/Plugin/Block/FooterBlockBase.php
+++ b/src/Plugin/Block/FooterBlockBase.php
@@ -79,9 +79,9 @@ abstract class FooterBlockBase extends BlockBase implements ContainerFactoryPlug
     $site_info_config = $this->configFactory->get('system.site');
     $cache->addCacheableDependency($site_info_config);
     $site_identity = $site_info_config->get('name');
+    NestedArray::setValue($build, ['#site_specific_footer', 'site_identity'], $site_identity);
 
     if (!empty($social_links) || !empty($general_links)) {
-      NestedArray::setValue($build, ['#site_specific_footer', 'site_identity'], $site_identity);
       NestedArray::setValue($build, ['#site_specific_footer', 'social_links'], $social_links);
       NestedArray::setValue($build, ['#site_specific_footer', 'other_links'], $general_links);
     }


### PR DESCRIPTION
## EWPP-131

### Description

Set site_identity, import site_info fix and fix service not found

### Change log

- Changed:
   - site_identity position outside condition
   - oe_corporate_site_info version to include site info config page fix.


