### PR TITLE
EWPP-628: Translations of string "Legal" missing from EU footer

### DIFF
--- a/config/schema/oe_corporate_blocks.schema.yml
+++ b/config/schema/oe_corporate_blocks.schema.yml
@@ -67,6 +67,7 @@ oe_corporate_blocks.eu_data.footer:
     legal_links_title:
       type: string
       label: 'Title of legal links column'
+      translatable: true
     legal_links:
       type: sequence
       label: 'Legal links'

--- a/translations/oe_corporate_blocks-bg.po
+++ b/translations/oe_corporate_blocks-bg.po
@@ -130,6 +130,9 @@ msgstr "Политика за поверителност"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_bg"
 
+msgid "Legal"
+msgstr "Правни аспекти"
+
 msgid "Legal notice"
 msgstr "Правна информация"
 

--- a/translations/oe_corporate_blocks-cs.po
+++ b/translations/oe_corporate_blocks-cs.po
@@ -124,6 +124,9 @@ msgstr "Politika ochrany soukromí"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_cs"
 
+msgid "Legal"
+msgstr "Právní informace"
+
 msgid "Legal notice"
 msgstr "Právní upozornění"
 

--- a/translations/oe_corporate_blocks-da.po
+++ b/translations/oe_corporate_blocks-da.po
@@ -127,6 +127,9 @@ msgstr "Databeskyttelsespolitik"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_da"
 
+msgid "Legal"
+msgstr "Juridiske forhold"
+
 msgid "Legal notice"
 msgstr "Juridisk meddelelse"
 

--- a/translations/oe_corporate_blocks-de.po
+++ b/translations/oe_corporate_blocks-de.po
@@ -130,6 +130,9 @@ msgstr "Schutz der Privatsphäre"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_de"
 
+msgid "Legal"
+msgstr "Rechtliche Hinweise"
+
 msgid "Legal notice"
 msgstr "Rechtlicher Hinweis"
 

--- a/translations/oe_corporate_blocks-el.po
+++ b/translations/oe_corporate_blocks-el.po
@@ -137,6 +137,9 @@ msgstr "Πολιτική απορρήτου"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_el"
 
+msgid "Legal"
+msgstr "Νομικό πλαίσιο"
+
 msgid "Legal notice"
 msgstr "Νομική ανακοίνωση"
 

--- a/translations/oe_corporate_blocks-es.po
+++ b/translations/oe_corporate_blocks-es.po
@@ -127,6 +127,9 @@ msgstr "Política de privacidad"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_es"
 
+msgid "Legal"
+msgstr "Aviso jurídico"
+
 msgid "Legal notice"
 msgstr "Aviso jurídico"
 

--- a/translations/oe_corporate_blocks-et.po
+++ b/translations/oe_corporate_blocks-et.po
@@ -124,6 +124,9 @@ msgstr "Isikuandmete kaitse"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_et"
 
+msgid "Legal"
+msgstr "Õigusteave"
+
 msgid "Legal notice"
 msgstr "Õigusteave"
 

--- a/translations/oe_corporate_blocks-fi.po
+++ b/translations/oe_corporate_blocks-fi.po
@@ -127,6 +127,9 @@ msgstr "Tietosuojaperiaatteet"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_fi"
 
+msgid "Legal"
+msgstr "Oikeudelliset ilmoitukset"
+
 msgid "Legal notice"
 msgstr "Oikeudellinen huomautus"
 

--- a/translations/oe_corporate_blocks-fr.po
+++ b/translations/oe_corporate_blocks-fr.po
@@ -130,6 +130,9 @@ msgstr "Protection de la vie privée"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_fr"
 
+msgid "Legal"
+msgstr "Avis juridique"
+
 msgid "Legal notice"
 msgstr "Avis juridique"
 

--- a/translations/oe_corporate_blocks-ga.po
+++ b/translations/oe_corporate_blocks-ga.po
@@ -121,6 +121,9 @@ msgstr "Beartas príobháideachais"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_ga"
 
+msgid "Legal"
+msgstr "Fógraí Dlíthiúla"
+
 msgid "Legal notice"
 msgstr "Fógra dlíthiúil"
 

--- a/translations/oe_corporate_blocks-hr.po
+++ b/translations/oe_corporate_blocks-hr.po
@@ -124,6 +124,9 @@ msgstr "Politika zaštite privatnosti"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_hr"
 
+msgid "Legal"
+msgstr "Pravne obavijesti"
+
 msgid "Legal notice"
 msgstr "Pravna obavijest"
 

--- a/translations/oe_corporate_blocks-hu.po
+++ b/translations/oe_corporate_blocks-hu.po
@@ -128,6 +128,9 @@ msgstr "Adatvédelem"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_hu"
 
+msgid "Legal"
+msgstr "Jogi információk"
+
 msgid "Legal notice"
 msgstr "Jogi nyilatkozat"
 

--- a/translations/oe_corporate_blocks-it.po
+++ b/translations/oe_corporate_blocks-it.po
@@ -124,6 +124,9 @@ msgstr "Politica in materia di privacy"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_it"
 
+msgid "Legal"
+msgstr "Informazioni legali"
+
 msgid "Legal notice"
 msgstr "Note legali"
 

--- a/translations/oe_corporate_blocks-lt.po
+++ b/translations/oe_corporate_blocks-lt.po
@@ -127,6 +127,9 @@ msgstr "Privatumo politika"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_lt"
 
+msgid "Legal"
+msgstr "Teisinis pranešimas"
+
 msgid "Legal notice"
 msgstr "Teisinis pranešimas"
 

--- a/translations/oe_corporate_blocks-lv.po
+++ b/translations/oe_corporate_blocks-lv.po
@@ -127,6 +127,9 @@ msgstr "Privātuma aizsardzība"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_lv"
 
+msgid "Legal"
+msgstr "Juridiski paziņojumi"
+
 msgid "Legal notice"
 msgstr "Juridisks paziņojums"
 

--- a/translations/oe_corporate_blocks-mt.po
+++ b/translations/oe_corporate_blocks-mt.po
@@ -127,6 +127,9 @@ msgstr "Politika ta’ privatezza"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_mt"
 
+msgid "Legal"
+msgstr "Legali"
+
 msgid "Legal notice"
 msgstr "Avviż legali"
 

--- a/translations/oe_corporate_blocks-nl.po
+++ b/translations/oe_corporate_blocks-nl.po
@@ -127,6 +127,9 @@ msgstr "Privacybeleid"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_nl"
 
+msgid "Legal"
+msgstr "Juridische informatie"
+
 msgid "Legal notice"
 msgstr "Juridische mededeling"
 

--- a/translations/oe_corporate_blocks-pl.po
+++ b/translations/oe_corporate_blocks-pl.po
@@ -127,6 +127,9 @@ msgstr "Polityka prywatności"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_pl"
 
+msgid "Legal"
+msgstr "Treści prawne"
+
 msgid "Legal notice"
 msgstr "Informacja prawna"
 

--- a/translations/oe_corporate_blocks-pt-pt.po
+++ b/translations/oe_corporate_blocks-pt-pt.po
@@ -124,6 +124,9 @@ msgstr "Política de privacidade"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_pt"
 
+msgid "Legal"
+msgstr "Aviso legal"
+
 msgid "Legal notice"
 msgstr "Advertência jurídica"
 

--- a/translations/oe_corporate_blocks-ro.po
+++ b/translations/oe_corporate_blocks-ro.po
@@ -127,6 +127,9 @@ msgstr "Politica de confidențialitate"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_ro"
 
+msgid "Legal"
+msgstr "Aviz juridic"
+
 msgid "Legal notice"
 msgstr "Aviz juridic"
 

--- a/translations/oe_corporate_blocks-sk.po
+++ b/translations/oe_corporate_blocks-sk.po
@@ -124,6 +124,9 @@ msgstr "Politika ochrany osobných údajov"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_sk"
 
+msgid "Legal"
+msgstr "Právna informácia"
+
 msgid "Legal notice"
 msgstr "Právne upozornenie"
 

--- a/translations/oe_corporate_blocks-sl.po
+++ b/translations/oe_corporate_blocks-sl.po
@@ -121,6 +121,9 @@ msgstr "Politika varstva zasebnost"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_sl"
 
+msgid "Legal"
+msgstr "Pravni pogoji"
+
 msgid "Legal notice"
 msgstr "Pravno obvestilo"
 

--- a/translations/oe_corporate_blocks-sv.po
+++ b/translations/oe_corporate_blocks-sv.po
@@ -124,6 +124,9 @@ msgstr "Integritetspolicy"
 msgid "https://europa.eu/european-union/abouteuropa/privacy-policy_en"
 msgstr "https://europa.eu/european-union/abouteuropa/privacy-policy_sv"
 
+msgid "Legal"
+msgstr "Rättsliga frågor"
+
 msgid "Legal notice"
 msgstr "Rättsligt meddelande"
 


### PR DESCRIPTION
## EWPP-628

Translation of word "Legal" that is used in EU footer configurations has been added.