### PR TITLE
EWPP-0000: Update minimum site info to use 0.3.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.2",
         "drupal/core": "^8.7",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/oe_corporate_site_info": "~0.3"
+        "openeuropa/oe_corporate_site_info": "^0.3.1"
     },
     "require-dev": {
         "composer/installers": "~1.5",


### PR DESCRIPTION
## EWPP

### Description

Update minimum site info to use 0.3.1.

### Change log

- Added:
- Changed:Update minimum site info to use 0.3.1.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

