### PR TITLE
OEL-3058: Check strings before deletion.

### DIFF
--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -338,13 +338,13 @@ function oe_corporate_blocks_post_update_40010(&$sandbox): void {
   // @see https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-2407
   if (\Drupal::moduleHandler()->moduleExists('locale')) {
     $storage = \Drupal::service('locale.storage');
-    $strings = [
-      ['source' => 'Search all EU institutions and bodies'],
-      ['source' => 'EU institutions and bodies'],
-      ['source' => 'https://european-union.europa.eu/institutions-law-budget/institutions-and-bodies/search-all-eu-institutions-and-bodies_en'],
+    $sources = [
+      'Search all EU institutions and bodies',
+      'EU institutions and bodies',
+      'https://european-union.europa.eu/institutions-law-budget/institutions-and-bodies/search-all-eu-institutions-and-bodies_en',
     ];
-    foreach ($strings as $string) {
-      $string = $storage->findString($string);
+    foreach ($sources as $source) {
+      $string = $storage->findString(['source' => $source]);
       if (!$string) {
         continue;
       }

--- a/oe_corporate_blocks.post_update.php
+++ b/oe_corporate_blocks.post_update.php
@@ -338,11 +338,17 @@ function oe_corporate_blocks_post_update_40010(&$sandbox): void {
   // @see https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-2407
   if (\Drupal::moduleHandler()->moduleExists('locale')) {
     $storage = \Drupal::service('locale.storage');
-    $string = $storage->findString(['source' => 'Search all EU institutions and bodies']);
-    $storage->delete($string);
-    $string = $storage->findString(['source' => 'EU institutions and bodies']);
-    $storage->delete($string);
-    $string = $storage->findString(['source' => 'https://european-union.europa.eu/institutions-law-budget/institutions-and-bodies/search-all-eu-institutions-and-bodies_en']);
-    $storage->delete($string);
+    $strings = [
+      ['source' => 'Search all EU institutions and bodies'],
+      ['source' => 'EU institutions and bodies'],
+      ['source' => 'https://european-union.europa.eu/institutions-law-budget/institutions-and-bodies/search-all-eu-institutions-and-bodies_en'],
+    ];
+    foreach ($strings as $string) {
+      $string = $storage->findString($string);
+      if (!$string) {
+        continue;
+      }
+      $storage->delete($string);
+    }
   }
 }


### PR DESCRIPTION
## OEL-3058

### Description

Websites other than ewpp may not have the strings, so when the local storage tries to fetch them the result will be null.

reported also in https://github.com/openeuropa/oe_corporate_blocks/issues/158

### Change log

- Fixed: oe_corporate_blocks_post_update_40010


