### PR TITLE
OEL-3170: Fix sparql namespace in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $databases["sparql_default"] = array(
     'prefix' => '',
     'host' => 'your-triple-store-host',
     'port' => '8890',
-    'namespace' => 'Drupal\\Driver\\Database\\sparql',
+    'namespace' => 'Drupal\\sparql_entity_storage\\Driver\\Database\\sparql',
     'driver' => 'sparql'
   )
 );


### PR DESCRIPTION
## OEL-3170

### Description

Fixes https://github.com/openeuropa/oe_corporate_blocks/issues/101

### Change log

- Fixed: Sparql namespace in README.md


